### PR TITLE
Add .fraction to PWMOut; redo crickit pin names

### DIFF
--- a/adafruit_seesaw/crickit.py
+++ b/adafruit_seesaw/crickit.py
@@ -26,45 +26,47 @@ from micropython import const
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_seesaw.git"
 
-_ADC_INPUT_0_PIN_CRICKIT = const(2)
-_ADC_INPUT_1_PIN_CRICKIT = const(3)
-_ADC_INPUT_2_PIN_CRICKIT = const(40)
-_ADC_INPUT_3_PIN_CRICKIT = const(41)
-_ADC_INPUT_4_PIN_CRICKIT = const(11)
-_ADC_INPUT_5_PIN_CRICKIT = const(10)
-_ADC_INPUT_6_PIN_CRICKIT = const(9)
-_ADC_INPUT_7_PIN_CRICKIT = const(8)
+_CRICKIT_SIGNAL1 = const(2)
+_CRICKIT_SIGNAL2 = const(3)
+_CRICKIT_SIGNAL3 = const(40)
+_CRICKIT_SIGNAL4 = const(41)
+_CRICKIT_SIGNAL5 = const(11)
+_CRICKIT_SIGNAL6 = const(10)
+_CRICKIT_SIGNAL7 = const(9)
+_CRICKIT_SIGNAL8 = const(8)
 
-_CRICKIT_S4 = const(14)
-_CRICKIT_S3 = const(15)
-_CRICKIT_S2 = const(16)
-_CRICKIT_S1 = const(17)
+_CRICKIT_SERVO1 = const(17)
+_CRICKIT_SERVO2 = const(16)
+_CRICKIT_SERVO3 = const(15)
+_CRICKIT_SERVO4 = const(14)
 
-_CRICKIT_M1_A1 = const(18)
-_CRICKIT_M1_A2 = const(19)
-_CRICKIT_M1_B1 = const(22)
-_CRICKIT_M1_B2 = const(23)
-_CRICKIT_DRIVE1 = const(42)
-_CRICKIT_DRIVE2 = const(43)
-_CRICKIT_DRIVE3 = const(12)
-_CRICKIT_DRIVE4 = const(13)
+_CRICKIT_MOTOR1A = const(22)
+_CRICKIT_MOTOR1B = const(23)
+_CRICKIT_MOTOR2A = const(19)
+_CRICKIT_MOTOR2B = const(18)
+_CRICKIT_DRIVE1 = const(13)
+_CRICKIT_DRIVE2 = const(12)
+_CRICKIT_DRIVE3 = const(43)
+_CRICKIT_DRIVE4 = const(42)
 
-_CRICKIT_CT1 = const(4)
-_CRICKIT_CT2 = const(5)
-_CRICKIT_CT3 = const(6)
-_CRICKIT_CT4 = const(7)
+_CRICKIT_CAPTOUCH1 = const(4)
+_CRICKIT_CAPTOUCH2 = const(5)
+_CRICKIT_CAPTOUCH3 = const(6)
+_CRICKIT_CAPTOUCH4 = const(7)
 
 class Crickit_Pinmap:
-    analog_pins = (_ADC_INPUT_0_PIN_CRICKIT, _ADC_INPUT_1_PIN_CRICKIT,
-                   _ADC_INPUT_2_PIN_CRICKIT, _ADC_INPUT_3_PIN_CRICKIT,
-                   _ADC_INPUT_4_PIN_CRICKIT, _ADC_INPUT_5_PIN_CRICKIT,
-                   _ADC_INPUT_6_PIN_CRICKIT, _ADC_INPUT_7_PIN_CRICKIT)
+    analog_pins = (_CRICKIT_SIGNAL1, _CRICKIT_SIGNAL2,
+                   _CRICKIT_SIGNAL3, _CRICKIT_SIGNAL4,
+                   _CRICKIT_SIGNAL5, _CRICKIT_SIGNAL6,
+                   _CRICKIT_SIGNAL7, _CRICKIT_SIGNAL8)
 
     pwm_width = 16
 
-    pwm_pins = (_CRICKIT_S4, _CRICKIT_S3, _CRICKIT_S2, _CRICKIT_S1,
-                _CRICKIT_M1_A1, _CRICKIT_M1_A2, _CRICKIT_M1_B1,
-                _CRICKIT_M1_B2, _CRICKIT_DRIVE1, _CRICKIT_DRIVE2,
+    pwm_pins = (_CRICKIT_SERVO1, _CRICKIT_SERVO2, _CRICKIT_SERVO3, _CRICKIT_SERVO4,
+                _CRICKIT_MOTOR1A, _CRICKIT_MOTOR2A,
+                _CRICKIT_MOTOR1B, _CRICKIT_MOTOR2B,
+                _CRICKIT_DRIVE1, _CRICKIT_DRIVE2,
                 _CRICKIT_DRIVE3, _CRICKIT_DRIVE4)
 
-    touch_pins = (_CRICKIT_CT1, _CRICKIT_CT2, _CRICKIT_CT3, _CRICKIT_CT4)
+    touch_pins = (_CRICKIT_CAPTOUCH1, _CRICKIT_CAPTOUCH2, _CRICKIT_CAPTOUCH3, _CRICKIT_CAPTOUCH4,
+                  _CRICKIT_SIGNAL1, _CRICKIT_SIGNAL2, _CRICKIT_SIGNAL3, _CRICKIT_SIGNAL4)

--- a/adafruit_seesaw/pwmout.py
+++ b/adafruit_seesaw/pwmout.py
@@ -44,13 +44,24 @@ class PWMOut:
 
     @property
     def duty_cycle(self):
-        """16 bit value that dictates how much of one cycle is high (1) versus low (0). 0xffff will
-           always be high, 0 will always be low and 0x7fff will be half high and then half low."""
+        """16-bit value that dictates how much of one cycle is high (1) versus low (0). 65535 (0xffff) will
+           always be high, 0 will always be low and 32767 (0x7fff) will be half high and then half low."""
         return self._dc
 
     @duty_cycle.setter
     def duty_cycle(self, value):
         if not 0 <= value <= 0xffff:
-            raise ValueError("Out of range")
+            raise ValueError("Must be 0 to 65535")
         self._seesaw.analog_write(self._pin, value)
         self._dc = value
+
+    @property
+    def fraction(self):
+        """Expresses duty_cycle as a fractional value. Ranges from 0.0-1.0."""
+        return self.duty_cycle / 65535
+
+    @fraction.setter
+    def fraction(self, value):
+        if not 0.0 <= value <= 1.0:
+            raise ValueError("Must be 0.0 to 1.0")
+        self.duty_cycle = int(value * 65535)

--- a/adafruit_seesaw/pwmout.py
+++ b/adafruit_seesaw/pwmout.py
@@ -44,8 +44,10 @@ class PWMOut:
 
     @property
     def duty_cycle(self):
-        """16-bit value that dictates how much of one cycle is high (1) versus low (0). 65535 (0xffff) will
-           always be high, 0 will always be low and 32767 (0x7fff) will be half high and then half low."""
+        """16-bit value that dictates how much of one cycle is high (1) versus low (0).
+        65535 (0xffff) will always be high, 0 will always be low,
+        and 32767 (0x7fff) will be half high and then half low.
+        """
         return self._dc
 
     @duty_cycle.setter


### PR DESCRIPTION
1. Redo Crickit pin names in crickit.py. These aren't used anywhere else, but I'm just clarifying the names a bit.

2. Add `PWMOut.fraction`. This allows setting a fractional duty cycle between 0.0 and 1.0 so the user doesn't need to remember 65535 as the upper limit. So for instance, fully on on a Crickit Drive terminal would be 1.0. Used in examples in the https://github.com/adafruit/Adafruit_CircuitPythonCrickit library.
