### PR TITLE
Update README Travis Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,8 @@ Introduction
     :target: https://discord.gg/nBQh6qu
     :alt: Discord
 
-.. image:: https://travis-ci.org/adafruit/Adafruit_CircuitPython_seesaw.svg?branch=master
-    :target: https://travis-ci.org/adafruit/Adafruit_CircuitPython_seesaw
+.. image:: https://travis-ci.com/adafruit/Adafruit_CircuitPython_seesaw.svg?branch=master
+    :target: https://travis-ci.com/adafruit/Adafruit_CircuitPython_seesaw
     :alt: Build Status
 
 CircuitPython module for use with the Adafruit ATSAMD09 seesaw.


### PR DESCRIPTION
Change 'travis-ci.org' to 'travis-ci.com'.