### PR TITLE
Add retries for moisture reading

### DIFF
--- a/adafruit_seesaw/seesaw.py
+++ b/adafruit_seesaw/seesaw.py
@@ -236,6 +236,17 @@ class Seesaw:
         self.read(_TOUCH_BASE, _TOUCH_CHANNEL_OFFSET, buf, .005)
         ret = struct.unpack(">H", buf)[0]
         time.sleep(.001)
+
+        # retry if reading was bad
+        count = 0
+        while ret > 4095:
+            self.read(_TOUCH_BASE, _TOUCH_CHANNEL_OFFSET, buf, .005)
+            ret = struct.unpack(">H", buf)[0]
+            time.sleep(.001)
+            count += 1
+            if count > 3:
+                raise RuntimeError("Could not get a valid moisture reading.")
+
         return ret
 
     def pin_mode_bulk(self, pins, mode):


### PR DESCRIPTION
Test setup:
![rpi_soil_test](https://user-images.githubusercontent.com/8755041/53212796-3db75800-35fb-11e9-934c-64be28ff9950.jpg)

Test script:
```python
import time
import board, busio
from adafruit_seesaw.seesaw import Seesaw

i2c = busio.I2C(board.SCL, board.SDA)

ss = Seesaw(i2c, addr=0x36)

start_time = time.time()
count = 0

print("Reading...")

while True:
    count += 1
    if ss.moisture_read() > 4095:
        break
    time.sleep(0.1)

print("DONE")
print("count = {}  time = {}".format(count, time.time()-start_time))
```

**BEFORE** :frowning_face: 
```
pi@raspberrypi:~/soil_sensor $ python3 soil_test.py 
Reading...
DONE
count = 223  time = 24.15417194366455
pi@raspberrypi:~/soil_sensor $ python3 soil_test.py 
Reading...
DONE
count = 15  time = 1.5329132080078125
pi@raspberrypi:~/soil_sensor $ python3 soil_test.py 
Reading...
DONE
count = 283  time = 30.68214201927185
pi@raspberrypi:~/soil_sensor $ 
```

**AFTER** :grin:
(ran for ~15 minutes before `<CTRL><C>`ing)
```
pi@raspberrypi:~/soil_sensor $ python3 soil_test.py 
Reading...
```

Basic reading still works:
```python
pi@raspberrypi:~/soil_sensor $ python3
Python 3.5.3 (default, Sep 27 2018, 17:25:39) 
[GCC 6.3.0 20170516] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import board, busio
>>> from adafruit_seesaw.seesaw import Seesaw
>>> i2c = busio.I2C(board.SCL, board.SDA)
>>> ss = Seesaw(i2c, addr=0x36)
>>> ss.moisture_read()
359
>>> ss.moisture_read()
1015
>>> ss.moisture_read()
362
>>> 
```