### PR TITLE
add delay to I2Cread for temperature reading

### DIFF
--- a/adafruit_seesaw/seesaw.py
+++ b/adafruit_seesaw/seesaw.py
@@ -328,7 +328,7 @@ class Seesaw:
 
     def get_temp(self):
         buf = bytearray(4)
-        self.read(_STATUS_BASE, _STATUS_TEMP, buf)
+        self.read(_STATUS_BASE, _STATUS_TEMP, buf, .005)
         buf[0] = buf[0] & 0x3F
         ret = struct.unpack(">I", buf)[0]
         return 0.00001525878 * ret


### PR DESCRIPTION
temperature reading had been working in the past, but now temperature readings were not being returned correctly. Not sure what changed but increasing the delay for the read fixed the problem.
This delay was already used for the moisture reading.

fixes #33 

Is this possibly due to recent "speedups" in CP in general?  Will other seesaw applications run into similar issues?  Is the default delay of .001 sufficient?

tested on feather_m4_express and pyportal