### PR TITLE
Fix white channel getting set 0.

### DIFF
--- a/adafruit_seesaw/neopixel.py
+++ b/adafruit_seesaw/neopixel.py
@@ -99,7 +99,7 @@ class NeoPixel:
 
         # If all components are the same and we have a white pixel then use it
         # instead of the individual components.
-        if self._bpp == 4 and r == g == b:
+        if self._bpp == 4 and r == g == b and w == 0:
             w = r
             r = 0
             g = 0


### PR DESCRIPTION
Fixes #32. I went with @EricGallimore 's suggestion.

Tested with Crickit HAT on RPi:
```python
pi@crickit:~ $ python3
Python 3.5.3 (default, Sep 27 2018, 17:25:39) 
[GCC 6.3.0 20170516] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import board
>>> from adafruit_seesaw.seesaw import Seesaw
>>> from adafruit_seesaw.neopixel import NeoPixel
>>> pixels = NeoPixel(Seesaw(board.I2C()), 20, 8, bpp=4, pixel_order=(1, 0, 2, 3))
>>> pixels.fill(0)
>>> pixels.fill((0,0,0,255))
```