### PR TITLE
Increased default delay because faster cp means it crashes sometimes

### DIFF
--- a/adafruit_seesaw/seesaw.py
+++ b/adafruit_seesaw/seesaw.py
@@ -372,7 +372,7 @@ class Seesaw:
         self.read(reg_base, reg, ret)
         return ret[0]
 
-    def read(self, reg_base, reg, buf, delay=.001):
+    def read(self, reg_base, reg, buf, delay=.003):
         self.write(reg_base, reg)
         if self._drdy is not None:
             while self._drdy.value is False:


### PR DESCRIPTION
This fixes the neotrellis issue (https://github.com/adafruit/circuitpython/issues/2110), so Neotrellis boards now work with the examples. Tested with CircuitPython 5.0 Alpha 3.