### PR TITLE
remove bad-whitespace pylint directive

### DIFF
--- a/adafruit_seesaw/keypad.py
+++ b/adafruit_seesaw/keypad.py
@@ -81,7 +81,7 @@ class Keypad(Seesaw):
     EDGE_RISING = 3
 
     def __init__(self, i2c_bus, addr=0x49, drdy=None):
-        super(Keypad, self).__init__(i2c_bus, addr, drdy)
+        super().__init__(i2c_bus, addr, drdy)
         self._interrupt_enabled = False
 
     @property

--- a/adafruit_seesaw/tftshield18.py
+++ b/adafruit_seesaw/tftshield18.py
@@ -84,7 +84,7 @@ class TFTShield18(Seesaw):
         _button_mask = 0xFF
 
     def __init__(self, i2c_bus=board.I2C(), addr=0x2E):
-        super(TFTShield18, self).__init__(i2c_bus, addr)
+        super().__init__(i2c_bus, addr)
         self.pin_mode(_TFTSHIELD_RESET_PIN, self.OUTPUT)
         self.pin_mode_bulk(self._button_mask, self.INPUT_PULLUP)
 

--- a/examples/seesaw_crickit_test.py
+++ b/examples/seesaw_crickit_test.py
@@ -1,8 +1,8 @@
 from board import SCL, SDA
 import busio
+from adafruit_motor import servo
 from adafruit_seesaw.seesaw import Seesaw
 from adafruit_seesaw.pwmout import PWMOut
-from adafruit_motor import servo
 
 # from analogio import AnalogOut
 # import board

--- a/examples/seesaw_joy_featherwing.py
+++ b/examples/seesaw_joy_featherwing.py
@@ -6,13 +6,11 @@ from micropython import const
 
 from adafruit_seesaw.seesaw import Seesaw
 
-# pylint: disable=bad-whitespace
 BUTTON_RIGHT = const(6)
 BUTTON_DOWN = const(7)
 BUTTON_LEFT = const(9)
 BUTTON_UP = const(10)
 BUTTON_SEL = const(14)
-# pylint: enable=bad-whitespace
 button_mask = const(
     (1 << BUTTON_RIGHT)
     | (1 << BUTTON_DOWN)

--- a/examples/seesaw_minitft_featherwing.py
+++ b/examples/seesaw_minitft_featherwing.py
@@ -5,7 +5,6 @@ from micropython import const
 
 from adafruit_seesaw.seesaw import Seesaw
 
-# pylint: disable=bad-whitespace
 BUTTON_RIGHT = const(7)
 BUTTON_DOWN = const(4)
 BUTTON_LEFT = const(3)
@@ -14,7 +13,6 @@ BUTTON_SEL = const(11)
 BUTTON_A = const(10)
 BUTTON_B = const(9)
 
-# pylint: enable=bad-whitespace
 button_mask = const(
     (1 << BUTTON_RIGHT)
     | (1 << BUTTON_DOWN)


### PR DESCRIPTION
This directive has been removed from pylint 2.6.0.