### PR TITLE
Support boards that don't have a fixed I2C bus.

### DIFF
--- a/adafruit_seesaw/tftshield18.py
+++ b/adafruit_seesaw/tftshield18.py
@@ -67,11 +67,11 @@ class TFTShield18(Seesaw):
         _button_mask = 0xFF
 
     def __init__(self, i2c_bus=None, addr=0x2E):
-        if i2c_bus == None:
-            if hasattr(board, "I2C"):
-                i2c_bus = board.I2C
-            else:
-                print("Warning: board has no default I2C bus.")
+        if i2c_bus is None:
+            try:
+                i2c_bus = board.I2C()
+            except AttributeError:
+                raise ValueError("Board has no default I2C bus.")
         super().__init__(i2c_bus, addr)
         self.pin_mode(_TFTSHIELD_RESET_PIN, self.OUTPUT)
         self.pin_mode_bulk(self._button_mask, self.INPUT_PULLUP)

--- a/adafruit_seesaw/tftshield18.py
+++ b/adafruit_seesaw/tftshield18.py
@@ -66,7 +66,12 @@ class TFTShield18(Seesaw):
         # TypeError: unsupported operand type(s) for <<: 'int' and '_MockObject'
         _button_mask = 0xFF
 
-    def __init__(self, i2c_bus=board.I2C(), addr=0x2E):
+    def __init__(self, i2c_bus=None, addr=0x2E):
+        if i2c_bus == None:
+            if hasattr(board, "I2C"):
+                i2c_bus = board.I2C
+            else:
+                print("Warning: board has no default I2C bus.")
         super().__init__(i2c_bus, addr)
         self.pin_mode(_TFTSHIELD_RESET_PIN, self.OUTPUT)
         self.pin_mode_bulk(self._button_mask, self.INPUT_PULLUP)

--- a/adafruit_seesaw/tftshield18.py
+++ b/adafruit_seesaw/tftshield18.py
@@ -70,8 +70,8 @@ class TFTShield18(Seesaw):
         if i2c_bus is None:
             try:
                 i2c_bus = board.I2C()
-            except AttributeError:
-                raise ValueError("Board has no default I2C bus.")
+            except AttributeError as attrError:
+                raise ValueError("Board has no default I2C bus.") from attrError
         super().__init__(i2c_bus, addr)
         self.pin_mode(_TFTSHIELD_RESET_PIN, self.OUTPUT)
         self.pin_mode_bulk(self._button_mask, self.INPUT_PULLUP)


### PR DESCRIPTION
Fixes #57 -- allows loading tftshield18 on the Raspberry Pi Pico.

Preserves the existing behavior on devices with board.I2C.
The Pico doesn't have a pre-defined I2C, you have to set it up with busio before you can instantiate the TFTShield18 object.

    import board
    import busio
    from adafruit_seesaw.tftshield18 import TFTShield18
    i2c_bus = busio.I2C(board.GP3, board.GP2)
    shield = TFTShield18(i2c_bus)