### PR TITLE
Add a convenience class that mimics rotaryio.IncrementalEncoder in the core

### DIFF
--- a/adafruit_seesaw/rotaryio.py
+++ b/adafruit_seesaw/rotaryio.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2017 Dean Miller for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+# pylint: disable=missing-docstring,invalid-name,too-many-public-methods
+
+
+"""
+`adafruit_seesaw.digitalio`
+====================================================
+"""
+
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_seesaw.git"
+
+
+class IncrementalEncoder:
+    """IncrementalEncoder determines the relative rotational position based
+    on two series of pulses."""
+
+    def __init__(self, seesaw, encoder=0):
+        """Create an IncrementalEncoder object associated with the given
+        eesaw device."""
+        self._seesaw = seesaw
+        self._encoder = encoder
+
+    @property
+    def position(self):
+        """The current position in terms of pulses. The number of pulses per
+        rotation is defined by the specific hardware."""
+        return self._seesaw.encoder_position(self._encoder)
+
+    @position.setter
+    def position(self, value):
+        self._seesaw.set_encoder_position(value, self._encoder)

--- a/examples/seesaw_rotary_simpletest.py
+++ b/examples/seesaw_rotary_simpletest.py
@@ -11,6 +11,11 @@ i2c_bus = busio.I2C(board.SCL, board.SDA)
 
 seesaw = Seesaw(i2c_bus, addr=0x36)
 
+seesaw_product = (seesaw.get_product() >> 16) & 0xFFFF
+print("Found product {}".format(seesaw_product))
+if seesaw_product != 4991:
+    print("Wrong firmware loaded?  Expected 4991")
+
 button = DigitalIO(seesaw, 24)
 button_held = False
 

--- a/examples/seesaw_rotary_simpletest.py
+++ b/examples/seesaw_rotary_simpletest.py
@@ -5,6 +5,7 @@ import board
 import busio
 from adafruit_seesaw.seesaw import Seesaw
 from adafruit_seesaw.digitalio import DigitalIO
+from adafruit_seesaw.rotaryio import IncrementalEncoder
 
 i2c_bus = busio.I2C(board.SCL, board.SDA)
 
@@ -13,12 +14,13 @@ seesaw = Seesaw(i2c_bus, addr=0x36)
 button = DigitalIO(seesaw, 24)
 button_held = False
 
-last_position = seesaw.encoder_position()
+encoder = IncrementalEncoder(seesaw)
+last_position = None
 
 while True:
 
     # read position of the rotary encoder
-    position = seesaw.encoder_position()
+    position = encoder.position
     if position != last_position:
         last_position = position
         print("Position: {}".format(position))

--- a/examples/seesaw_rotary_simpletest.py
+++ b/examples/seesaw_rotary_simpletest.py
@@ -11,7 +11,7 @@ i2c_bus = busio.I2C(board.SCL, board.SDA)
 
 seesaw = Seesaw(i2c_bus, addr=0x36)
 
-seesaw_product = (seesaw.get_product() >> 16) & 0xFFFF
+seesaw_product = (seesaw.get_version() >> 16) & 0xFFFF
 print("Found product {}".format(seesaw_product))
 if seesaw_product != 4991:
     print("Wrong firmware loaded?  Expected 4991")


### PR DESCRIPTION
and also check the product ID as suggested by @jerryneedell from the Arduino example.

The change to the initial value of `last_position` causes the initial position (usually 0) to be printed each time the program starts.