### PR TITLE
examples: Use board.I2C()

### DIFF
--- a/examples/seesaw_crickit_test.py
+++ b/examples/seesaw_crickit_test.py
@@ -1,8 +1,7 @@
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
-from board import SCL, SDA
-import busio
+import board
 from adafruit_motor import servo
 from adafruit_seesaw.seesaw import Seesaw
 from adafruit_seesaw.pwmout import PWMOut
@@ -10,7 +9,7 @@ from adafruit_seesaw.pwmout import PWMOut
 # from analogio import AnalogOut
 # import board
 
-i2c_bus = busio.I2C(SCL, SDA)
+i2c_bus = board.I2C()
 ss = Seesaw(i2c_bus)
 pwm1 = PWMOut(ss, 17)
 pwm2 = PWMOut(ss, 16)

--- a/examples/seesaw_joy_featherwing.py
+++ b/examples/seesaw_joy_featherwing.py
@@ -3,8 +3,7 @@
 
 import time
 
-from board import SCL, SDA
-import busio
+import board
 from micropython import const
 
 from adafruit_seesaw.seesaw import Seesaw
@@ -22,7 +21,7 @@ button_mask = const(
     | (1 << BUTTON_SEL)
 )
 
-i2c_bus = busio.I2C(SCL, SDA)
+i2c_bus = board.I2C()
 
 ss = Seesaw(i2c_bus)
 

--- a/examples/seesaw_rotary_simpletest.py
+++ b/examples/seesaw_rotary_simpletest.py
@@ -2,11 +2,10 @@
 # SPDX-License-Identifier: MIT
 
 import board
-import busio
 from adafruit_seesaw.seesaw import Seesaw
 from adafruit_seesaw.digitalio import DigitalIO
 
-i2c_bus = busio.I2C(board.SCL, board.SDA)
+i2c_bus = board.I2C()
 
 seesaw = Seesaw(i2c_bus, addr=0x36)
 

--- a/examples/seesaw_simpletest.py
+++ b/examples/seesaw_simpletest.py
@@ -7,11 +7,10 @@
 # https://learn.adafruit.com/adafruit-seesaw-atsamd09-breakout?view=all#circuitpython-wiring-and-test
 import time
 
-from board import SCL, SDA
-import busio
+import board
 from adafruit_seesaw.seesaw import Seesaw
 
-i2c_bus = busio.I2C(SCL, SDA)
+i2c_bus = board.I2C()
 
 ss = Seesaw(i2c_bus)
 

--- a/examples/seesaw_soil_simpletest.py
+++ b/examples/seesaw_soil_simpletest.py
@@ -3,12 +3,11 @@
 
 import time
 
-from board import SCL, SDA
-import busio
+import board
 
 from adafruit_seesaw.seesaw import Seesaw
 
-i2c_bus = busio.I2C(SCL, SDA)
+i2c_bus = board.I2C()
 
 ss = Seesaw(i2c_bus, addr=0x36)
 


### PR DESCRIPTION
I tested the rotaryio example only.