### PR TITLE
match rotary direction to standard rotaryio

### DIFF
--- a/adafruit_seesaw/seesaw.py
+++ b/adafruit_seesaw/seesaw.py
@@ -373,7 +373,7 @@ class Seesaw:
         """The current position of the encoder"""
         buf = bytearray(4)
         self.read(_ENCODER_BASE, _ENCODER_POSITION + encoder, buf)
-        return struct.unpack(">i", buf)[0]
+        return struct.unpack(">i", buf)[0] * -1
 
     def set_encoder_position(self, pos, encoder=0):
         """Set the current position of the encoder"""
@@ -384,7 +384,7 @@ class Seesaw:
         """The change in encoder position since it was last read"""
         buf = bytearray(4)
         self.read(_ENCODER_BASE, _ENCODER_DELTA + encoder, buf)
-        return struct.unpack(">i", buf)[0]
+        return struct.unpack(">i", buf)[0] * -1
 
     def enable_encoder_interrupt(self, encoder=0):
         """Enable the interrupt to fire when the encoder changes position"""

--- a/adafruit_seesaw/seesaw.py
+++ b/adafruit_seesaw/seesaw.py
@@ -373,6 +373,8 @@ class Seesaw:
         """The current position of the encoder"""
         buf = bytearray(4)
         self.read(_ENCODER_BASE, _ENCODER_POSITION + encoder, buf)
+
+        # using negation to make clockwise rotation positive
         return -struct.unpack(">i", buf)[0]
 
     def set_encoder_position(self, pos, encoder=0):
@@ -384,6 +386,8 @@ class Seesaw:
         """The change in encoder position since it was last read"""
         buf = bytearray(4)
         self.read(_ENCODER_BASE, _ENCODER_DELTA + encoder, buf)
+
+        # using negation to make clockwise rotation positive
         return -struct.unpack(">i", buf)[0]
 
     def enable_encoder_interrupt(self, encoder=0):

--- a/adafruit_seesaw/seesaw.py
+++ b/adafruit_seesaw/seesaw.py
@@ -373,7 +373,7 @@ class Seesaw:
         """The current position of the encoder"""
         buf = bytearray(4)
         self.read(_ENCODER_BASE, _ENCODER_POSITION + encoder, buf)
-        return struct.unpack(">i", buf)[0] * -1
+        return -struct.unpack(">i", buf)[0]
 
     def set_encoder_position(self, pos, encoder=0):
         """Set the current position of the encoder"""
@@ -384,7 +384,7 @@ class Seesaw:
         """The change in encoder position since it was last read"""
         buf = bytearray(4)
         self.read(_ENCODER_BASE, _ENCODER_DELTA + encoder, buf)
-        return struct.unpack(">i", buf)[0] * -1
+        return -struct.unpack(">i", buf)[0]
 
     def enable_encoder_interrupt(self, encoder=0):
         """Enable the interrupt to fire when the encoder changes position"""


### PR DESCRIPTION
This makes it so clockwise rotation is positive and counter-clockwise is negative to match the standard `rotaryio` library.