### PR TITLE
use rainbowio for colorwheel

### DIFF
--- a/examples/seesaw_rotary_neopixel.py
+++ b/examples/seesaw_rotary_neopixel.py
@@ -3,12 +3,10 @@
 
 """I2C rotary encoder NeoPixel color picker and brightness setting example."""
 import board
+from rainbowio import colorwheel
 from adafruit_seesaw import seesaw, neopixel, rotaryio, digitalio
 
-try:
-    import _pixelbuf
-except ImportError:
-    import adafruit_pypixelbuf as _pixelbuf
+
 
 # For use with the STEMMA connector on QT Py RP2040
 # import busio
@@ -42,7 +40,7 @@ while True:
             else:
                 color -= 1  # Advance backward through the colorwheel.
             color = (color + 256) % 256  # wrap around to 0-256
-            pixel.fill(_pixelbuf.colorwheel(color))
+            pixel.fill(colorwheel(color))
 
         else:  # If the button is pressed...
             # ...change the brightness.


### PR DESCRIPTION
with CP 7 colorwheel is moved from `_pixelbuf` to `rainbowio`

I do not have the hardware necessary to test the full example. But I did test the imports on Trinket M0 7.0.0 alpha6 and confirmed that it does have `rainbowio` even though it doesn't have `_pixelbuf` so the fallback to `adafruit_pixelbuf` should not be necessary any more.