### PR TITLE
Propagate delay param from read() to analog_read()

### DIFF
--- a/adafruit_seesaw/analoginput.py
+++ b/adafruit_seesaw/analoginput.py
@@ -21,9 +21,10 @@ class AnalogInput:
     :param ~adafruit_seesaw.seesaw.Seesaw seesaw: The device
     :param int pin: The pin number on the device"""
 
-    def __init__(self, seesaw, pin):
+    def __init__(self, seesaw, pin, delay=0.008):
         self._seesaw = seesaw
         self._pin = pin
+        self._delay = delay
 
     def deinit(self):
         pass
@@ -31,7 +32,7 @@ class AnalogInput:
     @property
     def value(self):
         """The current analog value on the pin, as an integer from 0..65535 (inclusive)"""
-        return self._seesaw.analog_read(self._pin)
+        return self._seesaw.analog_read(self._pin, self._delay)
 
     @property
     def reference_voltage(self):

--- a/adafruit_seesaw/seesaw.py
+++ b/adafruit_seesaw/seesaw.py
@@ -253,12 +253,7 @@ class Seesaw:
         elif self.chip_id == _SAMD09_HW_ID_CODE:
             offset = self.pin_mapping.analog_pins.index(pin)
 
-        self.read(
-            _ADC_BASE,
-            _ADC_CHANNEL_OFFSET + offset,
-            buf,
-            delay
-        )
+        self.read(_ADC_BASE, _ADC_CHANNEL_OFFSET + offset, buf, delay)
         ret = struct.unpack(">H", buf)[0]
         return ret
 

--- a/adafruit_seesaw/seesaw.py
+++ b/adafruit_seesaw/seesaw.py
@@ -242,7 +242,7 @@ class Seesaw:
         self.read(_GPIO_BASE, _GPIO_INTFLAG, buf, delay=delay)
         return struct.unpack(">I", buf)[0]
 
-    def analog_read(self, pin):
+    def analog_read(self, pin, delay=0.008):
         """Read the value of an analog pin by number"""
         buf = bytearray(2)
         if pin not in self.pin_mapping.analog_pins:
@@ -257,9 +257,9 @@ class Seesaw:
             _ADC_BASE,
             _ADC_CHANNEL_OFFSET + offset,
             buf,
+            delay
         )
         ret = struct.unpack(">H", buf)[0]
-        time.sleep(0.001)
         return ret
 
     def touch_read(self, pin):


### PR DESCRIPTION
The `seesaw.analog_read()` function has a fixed `time.sleep(0.001)` in addition to the default `time.sleep(0.008)` in `seesaw.read()`.  This PR removes that fixed delay, allows the user to specify the delay used in `read()`, and allows the delay to be specified in the creation of `AnalogInput` objects.  

Tested by @jedgarpark where he was experiencing an accumulated >40 milliseconds of UI lag when reading four NeoSliders.