### PR TITLE
Do not blank out the value read for pins PA30 and PA31.

### DIFF
--- a/adafruit_seesaw/seesaw.py
+++ b/adafruit_seesaw/seesaw.py
@@ -214,7 +214,6 @@ class Seesaw:
         """Get the values of all the pins on the 'A' port as a bitmask"""
         buf = bytearray(4)
         self.read(_GPIO_BASE, _GPIO_BULK, buf, delay=delay)
-        buf[0] = buf[0] & 0x3F
         ret = struct.unpack(">I", buf)[0]
         return ret & pins
 


### PR DESCRIPTION
Pins PA30 and PA31 are the SWDIO and SWDCLK pins. But nothing prevents them from being used as GPIO when a debugger is not connected.

So this PR stops masking the two bits corresponding to these pins so that they can be read if needed. As the user supplied `pins` mask is still applied, this should have no impact on code that was not already trying to read these pins.