### PR TITLE
Fix incorrect RGBW NeoPixel output

### DIFF
--- a/adafruit_seesaw/neopixel.py
+++ b/adafruit_seesaw/neopixel.py
@@ -59,7 +59,7 @@ class NeoPixel:
         pin,
         n,
         *,
-        bpp=3,
+        bpp=None,
         brightness=1.0,
         auto_write=True,
         pixel_order=None
@@ -67,11 +67,13 @@ class NeoPixel:
         # TODO: brightness not yet implemented.
         self._seesaw = seesaw
         self._pin = pin
-        self._bpp = bpp
         self.auto_write = auto_write
         self._n = n
         self._brightness = min(max(brightness, 0.0), 1.0)
         self._pixel_order = GRBW if pixel_order is None else pixel_order
+        self._bpp = len(self._pixel_order) if bpp is None else bpp
+        if self._bpp != len(self._pixel_order):
+            raise ValueError("Pixel order and bpp value do not agree.")
 
         cmd = bytearray([pin])
         self._seesaw.write(_NEOPIXEL_BASE, _NEOPIXEL_PIN, cmd)


### PR DESCRIPTION
Simple fix for #101.

This works:
```python
Adafruit CircuitPython 7.2.5 on 2022-04-06; Adafruit Feather M4 Express with samd51j19
>>> import board
>>> from adafruit_seesaw import seesaw, neopixel
>>> ss = seesaw.Seesaw(board.I2C())
>>> pixels = neopixel.NeoPixel(ss, 20, 12, pixel_order=neopixel.GRBW)
>>> pixels.fill(0xFF0000)
>>> 
```

This also works (assumes RGBW pixel order):
```python
Adafruit CircuitPython 7.2.5 on 2022-04-06; Adafruit Feather M4 Express with samd51j19
>>> import board
>>> from adafruit_seesaw import seesaw, neopixel
>>> ss = seesaw.Seesaw(board.I2C())
>>> pixels = neopixel.NeoPixel(ss, 20, 12, bpp=4)
>>> pixels.fill(0xFF0000)
>>> 
```

Trying to over specify incompatible values throws exception:
```python
Adafruit CircuitPython 7.2.5 on 2022-04-06; Adafruit Feather M4 Express with samd51j19
>>> import board
>>> from adafruit_seesaw import seesaw, neopixel
>>> ss = seesaw.Seesaw(board.I2C())
>>> pixels = neopixel.NeoPixel(ss, 20, 12, bpp=3, pixel_order=neopixel.GRBW)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/lib/adafruit_seesaw/neopixel.py", line 78, in __init__
ValueError: Pixel order and bpp value do not agree.
>>> 
```
```