### PR TITLE
Use pixelbuf

### DIFF
--- a/adafruit_seesaw/neopixel.py
+++ b/adafruit_seesaw/neopixel.py
@@ -44,6 +44,7 @@ RGBW = "RGBW"
 GRBW = "GRBW"
 """Green Red Blue White"""
 
+
 class NeoPixel(PixelBuf):
     """Control NeoPixels connected to a seesaw
 
@@ -95,7 +96,7 @@ class NeoPixel(PixelBuf):
         step = _OUTPUT_BUFFER_SIZE - 2
         for i in range(0, len(buffer), step):
             self.output_buffer[0:2] = struct.pack(">H", i)
-            self.output_buffer[2:] = buffer[i:i+step]
+            self.output_buffer[2:] = buffer[i : i + step]
             self._seesaw.write(_NEOPIXEL_BASE, _NEOPIXEL_BUF, self.output_buffer)
 
         self._seesaw.write(_NEOPIXEL_BASE, _NEOPIXEL_SHOW)

--- a/adafruit_seesaw/neopixel.py
+++ b/adafruit_seesaw/neopixel.py
@@ -35,16 +35,14 @@ _NEOPIXEL_SHOW = const(0x05)
 _OUTPUT_BUFFER_SIZE = const(24)
 
 # Pixel color order constants
-RGB = (0, 1, 2)
+RGB = "RGB"
 """Red Green Blue"""
-GRB = (1, 0, 2)
+GRB = "GRB"
 """Green Red Blue"""
-RGBW = (0, 1, 2, 3)
+RGBW = "RGBW"
 """Red Green Blue White"""
-GRBW = (1, 0, 2, 3)
+GRBW = "GRBW"
 """Green Red Blue White"""
-
-_pixel_orders = {GRB:"GRB", RGB:"RGB", RGBW:"RGBW", GRBW:"GRBW"}
 
 class NeoPixel(PixelBuf):
     """Control NeoPixels connected to a seesaw
@@ -71,10 +69,10 @@ class NeoPixel(PixelBuf):
     ):
         self._seesaw = seesaw
         self._pin = pin
-        # convert legacy pixel order into PixelBuf pixel order
         if not pixel_order:
             pixel_order = GRB if bpp == 3 else GRBW
         elif isinstance(pixel_order, tuple):
+            # convert legacy pixel order into PixelBuf pixel order
             order_list = ["RGBW"[order] for order in pixel_order]
             pixel_order = "".join(order_list)
 

--- a/adafruit_seesaw/neopixel.py
+++ b/adafruit_seesaw/neopixel.py
@@ -9,6 +9,7 @@
 ====================================================
 """
 import struct
+from adafruit_pixelbuf import PixelBuf
 
 try:
     from micropython import const
@@ -30,6 +31,9 @@ _NEOPIXEL_BUF_LENGTH = const(0x03)
 _NEOPIXEL_BUF = const(0x04)
 _NEOPIXEL_SHOW = const(0x05)
 
+# try lower values if IO errors
+_OUTPUT_BUFFER_SIZE = const(24)
+
 # Pixel color order constants
 RGB = (0, 1, 2)
 """Red Green Blue"""
@@ -40,8 +44,9 @@ RGBW = (0, 1, 2, 3)
 GRBW = (1, 0, 2, 3)
 """Green Red Blue White"""
 
+_pixel_orders = {GRB:"GRB", RGB:"RGB", RGBW:"RGBW", GRBW:"GRBW"}
 
-class NeoPixel:
+class NeoPixel(PixelBuf):
     """Control NeoPixels connected to a seesaw
 
     :param ~adafruit_seesaw.seesaw.Seesaw seesaw: The device
@@ -62,108 +67,40 @@ class NeoPixel:
         bpp=None,
         brightness=1.0,
         auto_write=True,
-        pixel_order=None
+        pixel_order="GRB"
     ):
-        # TODO: brightness not yet implemented.
         self._seesaw = seesaw
         self._pin = pin
-        self.auto_write = auto_write
-        self._n = n
-        self._brightness = min(max(brightness, 0.0), 1.0)
-        self._pixel_order = GRB if pixel_order is None else pixel_order
-        self._bpp = len(self._pixel_order) if bpp is None else bpp
-        if self._bpp != len(self._pixel_order):
-            raise ValueError("Pixel order and bpp value do not agree.")
+        # convert legacy pixel order into PixelBuf pixel order
+        if not pixel_order:
+            pixel_order = GRB if bpp == 3 else GRBW
+        elif isinstance(pixel_order, tuple):
+            order_list = ["RGBW"[order] for order in pixel_order]
+            pixel_order = "".join(order_list)
+
+        super().__init__(
+            size=n,
+            byteorder=pixel_order,
+            brightness=brightness,
+            auto_write=auto_write,
+        )
 
         cmd = bytearray([pin])
         self._seesaw.write(_NEOPIXEL_BASE, _NEOPIXEL_PIN, cmd)
-        cmd = struct.pack(">H", n * self._bpp)
+        cmd = struct.pack(">H", n * self.bpp)
         self._seesaw.write(_NEOPIXEL_BASE, _NEOPIXEL_BUF_LENGTH, cmd)
-        self._pre_brightness_color = [None] * n
+        self.output_buffer = bytearray(_OUTPUT_BUFFER_SIZE)
 
-    @property
-    def brightness(self):
-        """Overall brightness of the pixel"""
-        return self._brightness
+    def _transmit(self, buffer: bytearray) -> None:
+        """Update the pixels even if auto_write is False"""
 
-    @brightness.setter
-    def brightness(self, brightness):
-        # pylint: disable=attribute-defined-outside-init
-        self._brightness = min(max(brightness, 0.0), 1.0)
+        step = _OUTPUT_BUFFER_SIZE - 2
+        for i in range(0, len(buffer), step):
+            self.output_buffer[0:2] = struct.pack(">H", i)
+            self.output_buffer[2:] = buffer[i:i+step]
+            self._seesaw.write(_NEOPIXEL_BASE, _NEOPIXEL_BUF, self.output_buffer)
 
-        # Suppress auto_write while updating brightness.
-        current_auto_write = self.auto_write
-        self.auto_write = False
-        for i in range(self._n):
-            if self._pre_brightness_color[i] is not None:
-                self[i] = self._pre_brightness_color[i]
-        if current_auto_write:
-            self.show()
-        self.auto_write = current_auto_write
+        self._seesaw.write(_NEOPIXEL_BASE, _NEOPIXEL_SHOW)
 
     def deinit(self):
         pass
-
-    def __len__(self):
-        return self._n
-
-    def __setitem__(self, key, color):
-        """Set one pixel to a new value"""
-        cmd = bytearray(2 + self._bpp)
-        struct.pack_into(">H", cmd, 0, key * self._bpp)
-        if isinstance(color, int):
-            w = color >> 24
-            r = (color >> 16) & 0xFF
-            g = (color >> 8) & 0xFF
-            b = color & 0xFF
-        else:
-            if self._bpp == 3:
-                r, g, b = color
-            else:
-                r, g, b, w = color
-
-        self._pre_brightness_color[key] = color
-
-        # If all components are the same and we have a white pixel then use it
-        # instead of the individual components.
-        if self._bpp == 4 and r == g == b and w == 0:
-            w = r
-            r = 0
-            g = 0
-            b = 0
-
-        if self.brightness < 0.99:
-            r = int(r * self.brightness)
-            g = int(g * self.brightness)
-            b = int(b * self.brightness)
-            if self._bpp == 4:
-                w = int(w * self.brightness)
-
-        # Store colors in correct slots
-        cmd[2 + self._pixel_order[0]] = r
-        cmd[2 + self._pixel_order[1]] = g
-        cmd[2 + self._pixel_order[2]] = b
-        if self._bpp == 4:
-            cmd[2 + self._pixel_order[3]] = w
-
-        self._seesaw.write(_NEOPIXEL_BASE, _NEOPIXEL_BUF, cmd)
-        if self.auto_write:
-            self.show()
-
-    def __getitem__(self, key):
-        pass
-
-    def fill(self, color):
-        """Set all pixels to the same value"""
-        # Suppress auto_write while filling.
-        current_auto_write = self.auto_write
-        self.auto_write = False
-        for i in range(self._n):
-            self[i] = color
-        if current_auto_write:
-            self.show()
-        self.auto_write = current_auto_write
-
-    def show(self):
-        """Update the pixels even if auto_write is False"""
-        self._seesaw.write(_NEOPIXEL_BASE, _NEOPIXEL_SHOW)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,12 @@ extensions = [
 # Uncomment the below if you use native CircuitPython modules such as
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
-autodoc_mock_imports = ["adafruit_bus_device", "digitalio", "board"]
+autodoc_mock_imports = [
+    "adafruit_bus_device",
+    "adafruit_pixelbuf",
+    "board",
+    "digitalio",
+]
 
 autodoc_default_flags = ["special-members", "members"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@
 # SPDX-License-Identifier: Unlicense
 
 adafruit-circuitpython-busdevice
+adafruit-circuitpython-pixelbuf
 Adafruit-Blinka


### PR DESCRIPTION
Use PixelBuf to back the pixels buffer in the neopixel submodule.
This adds compatibility with the adafruit_led_animation library, in particular it adds: `__getitem__` and slices support. It sends pixel data all at once, but in chunks to avoid IO errors. It no longer sends pixel data as they are changed. Also switches the pixel order constants to strings, to match the neopixel API.

The size of the chunks is an estimate, I'm not sure if there are devices with seesaw builds that require a smaller size. Sending the whole strip of pixels at once can be quite slow with long pixel strips. This is the only way to do it with PixelBuf however, since the only access to the buffer is in `_transmit`.

Comparatively the original code would send pixels as they are modified, and only send a "show" command on show to the seesaw, basically putting the double buffer on the seesaw. This can actually be beneficial for some specific types of animations, but it's a tradeoff.

An alternative to this PR would be to add the PixelBuf API in python to the current implementation to keep the double buffering (and also optimize slices with chunks), for which the python version of PixelBuf might help.

I did some tests on Feather RP2040 with a Neokey 1x4 and a SAMD09 and ATTiny8x7 seesaw breakouts with a 30 pixels strip, no RGBW device. Additional tests on other seesaw boards would be nice.

Here is the test code:
```py
import time
import board
import busio

i2c_bus = board.I2C()

# Test with seesaw breakout
from adafruit_seesaw import neopixel
from adafruit_seesaw.seesaw import Seesaw
seesaw = Seesaw(i2c_bus)
pixels = neopixel.NeoPixel(seesaw, 3, 30)

# test with Neokey 1x4:
"""
from adafruit_neokey.neokey1x4 import NeoKey1x4
neokey = NeoKey1x4(i2c_bus)
neokey.pixels.fill(0)
pixels = neokey.pixels
"""

from adafruit_led_animation.animation.rainbow import Rainbow
from adafruit_led_animation.animation.chase import Chase
from adafruit_led_animation.animation.comet import Comet
from adafruit_led_animation.sequence import AnimationSequence
from adafruit_led_animation.color import AMBER, JADE

# works in the original version
comet = Comet(pixels, speed=0.02, color=JADE, tail_length=10, bounce=True)
# needs __getitem__, causes a MemoryError in the original version
chase = Chase(pixels, speed=0.04, size=3, spacing=6, color=AMBER)
# needs slices, causes TypeError in the original version
rainbow = Rainbow(pixels, speed=0.04)

while True:
    for x in range(100):
        comet.animate()
        time.sleep(0.01)
    for x in range(100):
        chase.animate()
        time.sleep(0.01)
    for x in range(100):
        rainbow.animate()
        time.sleep(0.01)
```

This should fix #105 