### PR TITLE
Ignore last 2 bits of digital input, only on boards without long ints

### DIFF
--- a/adafruit_seesaw/seesaw.py
+++ b/adafruit_seesaw/seesaw.py
@@ -214,7 +214,11 @@ class Seesaw:
         """Get the values of all the pins on the 'A' port as a bitmask"""
         buf = bytearray(4)
         self.read(_GPIO_BASE, _GPIO_BULK, buf, delay=delay)
-        ret = struct.unpack(">I", buf)[0]
+        try:
+            ret = struct.unpack(">I", buf)[0]
+        except OverflowError:
+            buf[0] = buf[0] & 0x3F
+            ret = struct.unpack(">I", buf)[0]
         return ret & pins
 
     def digital_read_bulk_b(self, pins, delay=0.008):


### PR DESCRIPTION
For compatibility on boards that don't support arbitrary integers. Bit 31 and 32 are scrubbed on these boards instead of throwing OverflowError, while builds with long ints retain this extra functionality.

Previous version breaks functionality for boards like QT Py SAMD21 using NeoKey 1x4 QT I2C Breakout or ATSAMD09 Breakout with Seesaw. More details in comments of issue [#107](https://github.com/adafruit/Adafruit_CircuitPython_seesaw/issues/107#issuecomment-1193398747).

Closes: #107 