### PR TITLE
Fix neopixel for python version of adafruit_pixelbuf

### DIFF
--- a/adafruit_seesaw/neopixel.py
+++ b/adafruit_seesaw/neopixel.py
@@ -78,7 +78,7 @@ class NeoPixel(PixelBuf):
             pixel_order = "".join(order_list)
 
         super().__init__(
-            size=n,
+            n,
             byteorder=pixel_order,
             brightness=brightness,
             auto_write=auto_write,


### PR DESCRIPTION
Using the neokey on a board without builtin adafruit_pixelbuf (using the python version) I get that:
```py
code.py output:
Traceback (most recent call last):
  File "code.py", line 9, in <module>
  File "adafruit_neokey/neokey1x4.py", line 64, in __init__
  File "adafruit_seesaw/neopixel.py", line 80, in __init__
TypeError: unexpected keyword argument 'size'
```
And indeed the size argument is called "n" in that version.
It's the positional argument anyway, no need for a name.