### PR TITLE
Add path check for neopixel.py

### DIFF
--- a/adafruit_seesaw/neopixel.py
+++ b/adafruit_seesaw/neopixel.py
@@ -21,7 +21,9 @@ except ImportError:
 
 ### hack to make sure this module is not placed in root CIRCUITPY/lib folder
 if "." not in __name__:
-    raise ImportError("seesaw neopixel being imported from wrong location")
+    raise ImportError(
+        "seesaw neopixel being imported from unexpected location - is seesaw neopixel use intended?"
+    )
 
 __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_seesaw.git"

--- a/adafruit_seesaw/neopixel.py
+++ b/adafruit_seesaw/neopixel.py
@@ -18,6 +18,9 @@ except ImportError:
     def const(x):
         return x
 
+### hack to make sure this module is not placed in root CIRCUITPY/lib folder
+if __file__.split('/')[-2] != 'adafruit_seesaw':
+    raise ImportError("seesaw neopixel being imported from wrong location")
 
 __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_seesaw.git"

--- a/adafruit_seesaw/neopixel.py
+++ b/adafruit_seesaw/neopixel.py
@@ -18,8 +18,9 @@ except ImportError:
     def const(x):
         return x
 
+
 ### hack to make sure this module is not placed in root CIRCUITPY/lib folder
-if __file__.split('/')[-2] != 'adafruit_seesaw':
+if __file__.split("/")[-2] != "adafruit_seesaw":
     raise ImportError("seesaw neopixel being imported from wrong location")
 
 __version__ = "0.0.0+auto.0"

--- a/adafruit_seesaw/neopixel.py
+++ b/adafruit_seesaw/neopixel.py
@@ -20,7 +20,7 @@ except ImportError:
 
 
 ### hack to make sure this module is not placed in root CIRCUITPY/lib folder
-if __file__.split("/")[-2] != "adafruit_seesaw":
+if "." not in __name__:
     raise ImportError("seesaw neopixel being imported from wrong location")
 
 __version__ = "0.0.0+auto.0"


### PR DESCRIPTION
A common issue is copying the seesaw version of `neopixel.py` into `CIRCUITPY/lib` instead of the "regular" non-seesaw `neopixel.py`. Then, when attempting to run a non-seesaw neopixel example, get:
```
TypeError: function missing required positional argument #4
```

This PR adds a simple path check to the seesaw `neopixel.py` to make sure it is located in a `adafruit_seesaw` folder. This should hopefully throw a more obvious error for the above scenario.

Attempting to import seesaw `neopixel.py` located in `CIRCUITPY/lib`:
```python
Adafruit CircuitPython 7.3.2 on 2022-07-20; Adafruit Metro M4 Airlift Lite with samd51j19
>>> import neopixel
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/lib/neopixel.py", line 23, in <module>
ImportError: seesaw neopixel being imported from wrong location
>>> 
```

Attempting to import seesaw `neopixel.py` located in `CIRCUITPY/lib/adafruit_seesaw`:
```python
Adafruit CircuitPython 7.3.2 on 2022-07-20; Adafruit Metro M4 Airlift Lite with samd51j19
>>> from adafruit_seesaw import neopixel
>>>  
```