### PR TITLE
Support ATtiny1616 and ATtiny816 boards

### DIFF
--- a/adafruit_seesaw/attinyx16.py
+++ b/adafruit_seesaw/attinyx16.py
@@ -1,10 +1,24 @@
+# SPDX-FileCopyrightText: 2017 Dean Miller for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+# pylint: disable=missing-docstring,invalid-name,too-many-public-methods,too-few-public-methods
+"""
+`adafruit_seesaw.attinyx16` - Pin definition for Adafruit ATtinyx16 Breakout with seesaw
+==================================================================================
+"""
+
+__version__ = "0.0.0+auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_seesaw.git"
+
+
 class ATtinyx16_Pinmap:
     """This class is automatically used by `adafruit_seesaw.seesaw.Seesaw` when
     a ATtinyx16 Breakout (PID 5690, PID 5681) is detected.
 
     It is also a reference for the capabilities of each pin."""
 
-    #: The pins capable of analog output
+    """The pins capable of analog output"""
     analog_pins = (0, 1, 2, 3, 4, 5, 14, 15, 16)
 
     """The effective bit resolution of the PWM pins"""

--- a/adafruit_seesaw/attinyx16.py
+++ b/adafruit_seesaw/attinyx16.py
@@ -1,0 +1,17 @@
+class ATtinyx16_Pinmap:
+    """This class is automatically used by `adafruit_seesaw.seesaw.Seesaw` when
+    a ATtinyx16 Breakout (PID 5690, PID 5681) is detected.
+
+    It is also a reference for the capabilities of each pin."""
+
+    #: The pins capable of analog output
+    analog_pins = (0, 1, 2, 3, 4, 5, 14, 15, 16)
+
+    """The effective bit resolution of the PWM pins"""
+    pwm_width = 16  # we dont actually use all 16 bits but whatever
+
+    """The pins capable of PWM output"""
+    pwm_pins = (0, 1, 7, 11, 16)
+
+    """No pins on this board are capable of touch input"""
+    touch_pins = ()

--- a/adafruit_seesaw/seesaw.py
+++ b/adafruit_seesaw/seesaw.py
@@ -117,7 +117,8 @@ _ENCODER_DELTA = const(0x40)
 # TODO: update when we get real PID
 _CRICKIT_PID = const(9999)
 _ROBOHATMM1_PID = const(9998)
-
+_5690_PID = const(5690)
+_5681_PID = const(5681)
 
 class Seesaw:
     """Driver for Seesaw i2c generic conversion trip
@@ -161,6 +162,10 @@ class Seesaw:
             from adafruit_seesaw.robohat import MM1_Pinmap
 
             self.pin_mapping = MM1_Pinmap
+        elif pid == _5690_PID or pid == _5681_PID:
+            from adafruit_seesaw.attinyx16 import ATtinyx16_Pinmap
+
+            self.pin_mapping = ATtinyx16_Pinmap
         elif self.chip_id == _SAMD09_HW_ID_CODE:
             from adafruit_seesaw.samd09 import SAMD09_Pinmap
 

--- a/adafruit_seesaw/seesaw.py
+++ b/adafruit_seesaw/seesaw.py
@@ -120,6 +120,7 @@ _ROBOHATMM1_PID = const(9998)
 _5690_PID = const(5690)
 _5681_PID = const(5681)
 
+
 class Seesaw:
     """Driver for Seesaw i2c generic conversion trip
 
@@ -162,7 +163,7 @@ class Seesaw:
             from adafruit_seesaw.robohat import MM1_Pinmap
 
             self.pin_mapping = MM1_Pinmap
-        elif pid == _5690_PID or pid == _5681_PID:
+        elif pid in (_5690_PID, _5681_PID):
             from adafruit_seesaw.attinyx16 import ATtinyx16_Pinmap
 
             self.pin_mapping = ATtinyx16_Pinmap


### PR DESCRIPTION
Currently library has incorrect pinmap for newer boards (PIDs 5690 & 5681). This PR adds a new pinmap file and test for it.