### PR TITLE
Update EEPROM I2C addr for ATtiny seesaw variants

### DIFF
--- a/adafruit_seesaw/seesaw.py
+++ b/adafruit_seesaw/seesaw.py
@@ -440,7 +440,7 @@ class Seesaw:
     #     return self.read8(SEESAW_SERCOM0_BASE + sercom, SEESAW_SERCOM_DATA)
 
     def _get_eeprom_i2c_addr(self):
-        """ Return the EEPROM address used to store I2C address."""
+        """Return the EEPROM address used to store I2C address."""
         chip_id = self.chip_id
         if chip_id in (
             _ATTINY806_HW_ID_CODE,

--- a/adafruit_seesaw/seesaw.py
+++ b/adafruit_seesaw/seesaw.py
@@ -457,7 +457,7 @@ class Seesaw:
         elif chip_id in (_SAMD09_HW_ID_CODE,):
             return 0x3F
         else:
-            raise RuntimeError("Unknown chip id", hex(chip_id))
+            return None
 
     def set_i2c_addr(self, addr):
         """Store a new address in the device's EEPROM and reboot it."""

--- a/adafruit_seesaw/seesaw.py
+++ b/adafruit_seesaw/seesaw.py
@@ -449,15 +449,14 @@ class Seesaw:
             _ATTINY817_HW_ID_CODE,
         ):
             return 0x7F
-        elif chip_id in (
+        if chip_id in (
             _ATTINY1616_HW_ID_CODE,
             _ATTINY1617_HW_ID_CODE,
         ):
             return 0xFF
-        elif chip_id in (_SAMD09_HW_ID_CODE,):
+        if chip_id in (_SAMD09_HW_ID_CODE,):
             return 0x3F
-        else:
-            return None
+        return None
 
     def set_i2c_addr(self, addr):
         """Store a new address in the device's EEPROM and reboot it."""

--- a/adafruit_seesaw/seesaw.py
+++ b/adafruit_seesaw/seesaw.py
@@ -439,7 +439,6 @@ class Seesaw:
     #
     #     return self.read8(SEESAW_SERCOM0_BASE + sercom, SEESAW_SERCOM_DATA)
 
-
     def _get_eeprom_i2c_addr(self):
         """ Return the EEPROM address used to store I2C address."""
         chip_id = self.chip_id
@@ -455,9 +454,7 @@ class Seesaw:
             _ATTINY1617_HW_ID_CODE,
         ):
             return 0xFF
-        elif chip_id in (
-            _SAMD09_HW_ID_CODE,
-        ):
+        elif chip_id in (_SAMD09_HW_ID_CODE,):
             return 0x3F
         else:
             raise RuntimeError("Unknown chip id", hex(chip_id))


### PR DESCRIPTION
This is for #122.

**NOTE**: The attempt to dynamically change the address for the underlying I2CDevice has been removed. It was hack that doesn't work. The `device_address` member is not directly accessible anymore now that BusDevice has moved to a builtin library.

Tested using a QT Py RP2040 and a Gamepad STEMMA QT.

