### PR TITLE
Fix `set_pwm_freq()` for ATtinys

### DIFF
--- a/adafruit_seesaw/attiny8x7.py
+++ b/adafruit_seesaw/attiny8x7.py
@@ -26,8 +26,8 @@ class ATtiny8x7_Pinmap:
     pwm_width = 16  # we dont actually use all 16 bits but whatever
 
     """The pins capable of PWM output"""
-    pwm_pins =  (0, 1, 9, 12, 13)  # 8 bit PWM mode
-    pwm_pins += (6, 7, 8)          # 16 bit PWM mode
+    pwm_pins = (0, 1, 9, 12, 13)  # 8 bit PWM mode
+    pwm_pins += (6, 7, 8)  # 16 bit PWM mode
 
     """No pins on this board are capable of touch input"""
     touch_pins = ()

--- a/adafruit_seesaw/attiny8x7.py
+++ b/adafruit_seesaw/attiny8x7.py
@@ -26,7 +26,8 @@ class ATtiny8x7_Pinmap:
     pwm_width = 16  # we dont actually use all 16 bits but whatever
 
     """The pins capable of PWM output"""
-    pwm_pins = (0, 1, 9, 12, 13)
+    pwm_pins =  (0, 1, 9, 12, 13)  # 8 bit PWM mode
+    pwm_pins += (6, 7, 8)          # 16 bit PWM mode
 
     """No pins on this board are capable of touch input"""
     touch_pins = ()

--- a/adafruit_seesaw/attinyx16.py
+++ b/adafruit_seesaw/attinyx16.py
@@ -25,8 +25,8 @@ class ATtinyx16_Pinmap:
     pwm_width = 16  # we dont actually use all 16 bits but whatever
 
     """The pins capable of PWM output"""
-    pwm_pins =  (0, 1, 7, 11, 16)  # 8 bit PWM mode
-    pwm_pins += (4, 5, 6)          # 16 bit PWM mode
+    pwm_pins = (0, 1, 7, 11, 16)  # 8 bit PWM mode
+    pwm_pins += (4, 5, 6)  # 16 bit PWM mode
 
     """No pins on this board are capable of touch input"""
     touch_pins = ()

--- a/adafruit_seesaw/attinyx16.py
+++ b/adafruit_seesaw/attinyx16.py
@@ -25,7 +25,8 @@ class ATtinyx16_Pinmap:
     pwm_width = 16  # we dont actually use all 16 bits but whatever
 
     """The pins capable of PWM output"""
-    pwm_pins = (0, 1, 7, 11, 16)
+    pwm_pins =  (0, 1, 7, 11, 16)  # 8 bit PWM mode
+    pwm_pins += (4, 5, 6)          # 16 bit PWM mode
 
     """No pins on this board are capable of touch input"""
     touch_pins = ()

--- a/adafruit_seesaw/seesaw.py
+++ b/adafruit_seesaw/seesaw.py
@@ -390,13 +390,16 @@ class Seesaw:
 
     def set_pwm_freq(self, pin, freq):
         """Set the PWM frequency of a pin by number"""
-        if pin in self.pin_mapping.pwm_pins:
-            cmd = bytearray(
-                [self.pin_mapping.pwm_pins.index(pin), (freq >> 8), freq & 0xFF]
-            )
-            self.write(_TIMER_BASE, _TIMER_FREQ, cmd)
-        else:
+        if pin not in self.pin_mapping.pwm_pins:
             raise ValueError("Invalid PWM pin")
+
+        if self.chip_id == _SAMD09_HW_ID_CODE:
+            offset = self.pin_mapping.pwm_pins.index(pin)
+        else:
+            offset = pin
+
+        cmd = bytearray([offset, (freq >> 8), freq & 0xFF])
+        self.write(_TIMER_BASE, _TIMER_FREQ, cmd)
 
     def encoder_position(self, encoder=0):
         """The current position of the encoder"""


### PR DESCRIPTION
For #116 (got issue number wrong in PR fork name)

**NOTE:** The `pwm_pins` for attiny8x7 and attinyx16 have been set to include pins for **both** 8 bit PWM mode and 16 bit PWM mode (a more recent firmware feature). However, only one mode will actually be built into the firmware. There is currently no way to query this from the firmware so that `pwm_pins` could be adjusted at runtime.

Tested on an ATtiny816 seesaw breakout with this code:
```python
import board
from adafruit_seesaw import seesaw
ss = seesaw.Seesaw(board.STEMMA_I2C())
ss.set_pwm_freq(11, 50)
```

**BEFORE**
no output, so waiting forever to trigger
![before](https://github.com/adafruit/Adafruit_CircuitPython_seesaw/assets/8755041/d47f8c10-6482-4c8f-bda6-b6d7457c5257)


**AFTER**
expected output on pin 11
![after](https://github.com/adafruit/Adafruit_CircuitPython_seesaw/assets/8755041/a5366b7b-dd85-4131-a5ff-23a24c0487f1)
