### PR TITLE
Issue 128: Fixed an error message that was using the wrong number system

### DIFF
--- a/adafruit_seesaw/seesaw.py
+++ b/adafruit_seesaw/seesaw.py
@@ -159,7 +159,7 @@ class Seesaw:
             _SAMD09_HW_ID_CODE,
         ):
             raise RuntimeError(
-                f"Seesaw hardware ID returned 0x{self.chip_id} is not "
+                f"Seesaw hardware ID returned 0x{self.chip_id:x} is not "
                 "correct! Please check your wiring."
             )
 


### PR DESCRIPTION
Added the hex formatter back to the the chip id error message.