### PR TITLE
Add delay argument to analog_write

### DIFF
--- a/adafruit_seesaw/seesaw.py
+++ b/adafruit_seesaw/seesaw.py
@@ -358,7 +358,7 @@ class Seesaw:
         else:
             self.write(_GPIO_BASE, _GPIO_BULK_CLR, cmd)
 
-    def analog_write(self, pin, value):
+    def analog_write(self, pin, value, delay=0.001):
         """Set the value of an analog output by number"""
         if pin not in self.pin_mapping.pwm_pins:
             raise ValueError("Invalid PWM pin")
@@ -374,7 +374,7 @@ class Seesaw:
             cmd = bytearray([offset, value])
 
         self.write(_TIMER_BASE, _TIMER_PWM, cmd)
-        time.sleep(0.001)
+        time.sleep(delay)
 
     def get_temp(self):
         """Read the temperature"""


### PR DESCRIPTION
I'm using a ATTiny817 Seesaw in an application where I need the main code to execute as fast as possible. When sending PWM commands to the Seesaw, the current analog_write method has a blocking `time.sleep(0.001)` that would introduce an unwanted delay in the loop. I propose to add an argument that would allow the user to modify this as necessary for their code. 

This has been tested with a ESP32-S3-DevKitC-1-N8R8 successfully using a delay of 0 and only calling analog_write at random intervals ranging from 50 to 100 milliseconds.

I feel this is consistent with https://github.com/adafruit/Adafruit_CircuitPython_seesaw/pull/90 that similarly allowed for users to decrease the delay on analog_read commands. The default behavior of this change still implements a one millisecond delay, so it should have no effect on existing code that uses this library.